### PR TITLE
Remove unsupported distribution from cargo-dist

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ installers = []
 # Target platforms to build apps for (Rust target-triple syntax)
 targets = [
     "aarch64-apple-darwin",
-    "aarch64-unknown-linux-gnu",
     "x86_64-apple-darwin",
     "x86_64-unknown-linux-gnu",
 ]


### PR DESCRIPTION
After trying to create a release it became evident that arm64+linux-gnu weren't distribution options, so remove the invalid option.
