### PR TITLE
Update to use Rust 1.80's built-in LazyLock

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     ":dependencyDashboard",
     "group:monorepos",
@@ -15,5 +16,23 @@
   },
   "github-actions": {
     "ignorePaths": [".github/workflows/release.yml"]
-  }
+  },
+  "regexManagers": [
+    {
+      "fileMatch": ["^rust-toolchain\\.toml?$"],
+      "matchStrings": [
+        "channel\\s*=\\s*\"(?<currentValue>\\d+\\.\\d+(\\.\\d+)?)\""
+      ],
+      "depNameTemplate": "rust",
+      "lookupNameTemplate": "rust-lang/rust",
+      "datasourceTemplate": "github-releases"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["regex"],
+      "matchPackageNames": ["rust"],
+      "commitMessageTopic": "Rust"
+    }
+  ]
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1001,7 +1001,6 @@ dependencies = [
  "aws-sdk-ecr",
  "clap",
  "futures",
- "once_cell",
  "regex",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,15 +5,14 @@ edition = "2021"
 repository = "https://github.com/theoremlp/ociupdate"
 
 [dependencies]
+aws-config = "1.4.0"
+aws-sdk-ecr = "1.25.0"
 clap = { version = "4.5.4", features = ["derive"] }
+futures = "0.3.30"
 regex = "1.10.4"
 serde = { version = "1.0.200", features = ["derive"] }
 serde_json = "1.0.116"
-aws-config = "1.4.0"
-aws-sdk-ecr = "1.25.0"
 tokio = { version = "1.37.0", features = ["full"] }
-once_cell = "1.19.0"
-futures = "0.3.30"
 
 # The profile that 'cargo dist' will build with
 [profile.dist]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,4 @@
 [toolchain]
 current = "1.80"
+components = ["rustfmt", "rustc"]
+profile = "default"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+current = "1.80"

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -1,6 +1,5 @@
-use once_cell::sync::Lazy as LazyLock;
-
 use regex::Regex;
+use std::sync::LazyLock;
 
 static REPO_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,8 +1,5 @@
-use std::fmt::Display;
-
-use once_cell::sync::Lazy as LazyLock;
-
 use regex::{Captures, Regex};
+use std::{fmt::Display, sync::LazyLock};
 
 static VERSION_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(


### PR DESCRIPTION
We were waiting for LazyLock to stabilize, specify the rust version and use built-in LazyLock.
